### PR TITLE
Add sleeping status to Medium Editor and wangEditor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ WYSIWYG Editors that can be use without dependecy to other libraries or framewor
 - [Froala Editor](https://github.com/froala/wysiwyg-editor) `$ Non-Free ⊘ Proprietary` - A beautifuly designed WYSIWYG Rich Text Editor based on HTML5.
 - [grande.js](https://github.com/mduvall/grande.js) - It's a Medium at Starbucks. Pinky ring out. :sleeping:
 - [Jodit](https://github.com/xdan/jodit) - Rich HTML WYSIWYG Editor and FileBrowser.
-- [Medium Editor](https://github.com/yabwe/medium-editor) - Medium.com WYSIWYG editor clone. Uses contenteditable API to implement a rich text solution.
+- [Medium Editor](https://github.com/yabwe/medium-editor) - Medium.com WYSIWYG editor clone. Uses contenteditable API to implement a rich text solution. :sleeping:
 - [Medium.js](https://github.com/jakiestfu/Medium.js) - A tiny JavaScript library for making contenteditable beautiful (Like Medium's editor). :sleeping:
 - [Milkdown](https://github.com/Saul-Mirone/milkdown) - Plugin driven WYSIWYG markdown editor framework.
 - [Mobiledoc Kit](https://github.com/bustlelabs/mobiledoc-kit) - A toolkit for building WYSIWYG editors with Mobiledoc. :sleeping:
@@ -44,7 +44,7 @@ WYSIWYG Editors that can be use without dependecy to other libraries or framewor
 - [Trix](https://github.com/basecamp/trix) - A rich text editor for everyday writing.
 - [Tui Editor](http://ui.toast.com/tui-editor) - Markdown WYSIWYG Editor. GFM Standard + Chart & UML Extensible. :sleepy:
 - [UEditor](https://github.com/fex-team/ueditor) - UEditor is a WYSIWYG rich web editor developed by Baidu fex-team. It is lightweight, customizable, and user-oriented. :sleeping:
-- [wangEditor](https://github.com/wangeditor-team/wangEditor/blob/master/README-en.md) - A lightweight rich text editor, friendly API and use extremely convenient. :sleepy:
+- [wangEditor](https://github.com/wangeditor-team/wangEditor/blob/master/README-en.md) - A lightweight rich text editor, friendly API and use extremely convenient. :sleeping:
 - [wysihtml](https://github.com/Voog/wysihtml) - Open source rich text editor for the modern web. :sleeping:
 - [on CodeMerge](https://github.com/s00d/on-codemerge) -  A modular, open source rich text editor.
 


### PR DESCRIPTION
The last commit in https://github.com/wangeditor-team/wangEditor/commit/f35d8a73a0a3dc159134d483afc5963d0256ea18 only removed their domain name from the readme