### PR TITLE
docs: add Puck to React section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,7 @@ Editors for your React-based project.
 - [megadraft](https://github.com/globocom/megadraft) - Megadraft is a Rich Text editor built on top of Facebook's Draft.JS featuring a nice default base of components and extensibility
 - [Plasmic](https://github.com/plasmicapp/plasmic) - A WYSIWYG visual builder that lets you drag and drop React components.
 - [Plate](https://github.com/udecode/plate) - A rich-text editor based on slate.js powered by AI.Easily build a Notion-like editor.
+- [Puck](https://github.com/measuredco/puck) -  Embeddable visual editor for creating your own page builder.
 - [React Draft Wysiwyg](https://github.com/jpuri/react-draft-wysiwyg) - A Wysiwyg editor build on top of React and DraftJS.
 - [react-froala-wysiwyg](https://github.com/froala/react-froala-wysiwyg) `$ Non-Free` - React component for Froala WYSIWYG HTML Rich Text Editor.
 - [react-mobiledoc-editor](https://github.com/upworthy/react-mobiledoc-editor) - A Mobiledoc editor written with React and Mobiledoc-Kit. :sleeping:


### PR DESCRIPTION
Thanks for maintaining this! I'd like to add [Puck](https://github.com/measuredco/puck) to the list.